### PR TITLE
Allow styles to be set on Tab components

### DIFF
--- a/lib/components/Tab.js
+++ b/lib/components/Tab.js
@@ -24,6 +24,7 @@ module.exports = React.createClass({
     selected: PropTypes.bool,
     disabled: PropTypes.bool,
     panelId: PropTypes.string,
+    style: PropTypes.object,
     children: PropTypes.oneOfType([
       PropTypes.array,
       PropTypes.object,
@@ -59,6 +60,7 @@ module.exports = React.createClass({
             'ReactTabs__Tab--disabled': this.props.disabled
           }
         )}
+        style={this.props.style}
         role="tab"
         id={this.props.id}
         aria-selected={this.props.selected ? 'true' : 'false'}


### PR DESCRIPTION
Since they are pretty simple (and will likely often just contain a string that represents the name of the tag) it would be nice to style them directly.
